### PR TITLE
Detailed install instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ Kill and reload emacs:
     emacsclient -e '(kill-emacs)'
     emacs --daemon
 
-*Done, yay!*
+**Done, yay!**
 
 Now you are ready to use `gnus-outlook-style`.
 
-*TODO:* add instructions on how to actually edit emails in `gnus` and `mu4e`.
+**TODO:** add instructions on how to actually edit emails in `gnus` and `mu4e`.
 
 A note on the helper application
 --------------------------------


### PR DESCRIPTION
I'm trying to use this with `mu4e`, it often bugs me that when I join a thread of comments, my email has to overwrite the html with converted plaintext.

I was quite clueless on how to install this, but eventually found out and wrote it up.

So I managed to compile the binary helper, but what now? How do I open emails with this in `mu4e`? Is there something similar to the `org-mu4e-compose-org-mode` function?

Note the **TODO:** add instructions on how to actually edit emails in `gnus` and `mu4e`.
